### PR TITLE
Avoid 10x memory usage in Python2 by using xrange in some programs

### DIFF
--- a/bencher/programs/fannkuchredux/fannkuchredux.python
+++ b/bencher/programs/fannkuchredux/fannkuchredux.python
@@ -16,7 +16,7 @@ MAX_CPU_LIMIT = 4
 
 def PermutationGenerator(length,idx):
     count = [0] * length
-    perm =  list(range(length))
+    perm =  range(length)
         
     for i in range( length - 1, 0, -1 ):
         d, idx  = divmod(idx, math.factorial(i))
@@ -45,7 +45,7 @@ def task_body( parms ):
 
   maxflips = 0
   checksum = 0
-  for i in range(parms[1], parms[2]):
+  for i in xrange(parms[1], parms[2]):
       data = list(g.next() if sys.version_info[0]<3 else g.__next__() )
       f =  data[0];
       if f > 0:
@@ -77,7 +77,7 @@ def main():
     index_max = math.factorial(length)
     index_step = (index_max + n-1) // n
 
-    parms =  [(length,i,i+index_step) for i in range(0,index_max,index_step) ]
+    parms =  [(length,i,i+index_step) for i in xrange(0,index_max,index_step) ]
 
     processors = Pool(processes=n)
     res=list(zip(*processors.map(task_body , parms)))

--- a/bencher/programs/iobench/iobench.python
+++ b/bencher/programs/iobench/iobench.python
@@ -8,23 +8,23 @@ def measure(func, num1, num2):
 
 def fwrite(num, num2):
     fd = os.open("/dev/null", os.O_WRONLY)
-    for i in range(num):
+    for i in xrange(num):
         os.write(fd, " " * num2)
 
 def fread(num, num2):
     fd = os.open("/dev/full", os.O_RDONLY)
-    for i in range(num):
+    for i in xrange(num):
         os.read(fd, num2)
 
 def file_write(num, num2):
     f = open("/dev/null", "w")
-    for i in range(num):
+    for i in xrange(num):
         f.write(" " * num2)
     f.flush()
 
 def file_read(num, num2):
     f = open("/dev/full")
-    for i in range(num):
+    for i in xrange(num):
         f.read(num2)
 
 if __name__ == '__main__':

--- a/bencher/programs/nbody/nbody.python
+++ b/bencher/programs/nbody/nbody.python
@@ -62,7 +62,7 @@ PAIRS = combinations(SYSTEM)
 
 def advance(dt, n, bodies=SYSTEM, pairs=PAIRS):
 
-    for i in range(n):
+    for i in xrange(n):
         for (([x1, y1, z1], v1, m1),
              ([x2, y2, z2], v2, m2)) in pairs:
             dx = x1 - x2


### PR DESCRIPTION
Idiomatic thing to do in iobench is use itertools.repeat